### PR TITLE
Implement splitting AsyncPtyMaster into halves

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ script:
   - |
     cargo fmt --all -- --check &&
     cargo build --verbose &&
-    cargo test
+    cargo test --all

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,10 +932,12 @@ dependencies = [
 name = "tokio-pty-process"
 version = "0.3.1"
 dependencies = [
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/tokio-pty-process/Cargo.toml
+++ b/tokio-pty-process/Cargo.toml
@@ -15,8 +15,10 @@ categories = ["asynchronous", "os::unix-apis"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
+bytes = "0.4.11"
 futures = "0.1"
 libc = "0.2"
 mio = "0.6"
 tokio = "0.1.7"
+tokio-io = "0.1.10"
 tokio-signal = "0.2.1"

--- a/tokio-pty-process/src/split.rs
+++ b/tokio-pty-process/src/split.rs
@@ -1,0 +1,144 @@
+// Copyright (c) 2019 Fabian Freyer
+// Copyright (c) 2018 Tokio Contributors
+//
+// Permission is hereby granted, free of charge, to any
+// person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the
+// Software without restriction, including without
+// limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice
+// shall be included in all copies or substantial portions
+// of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+// ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+// SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+// IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use bytes::{Buf, BufMut};
+use futures::sync::BiLock;
+use futures::{Async, Poll};
+use std::io::{self, Read, Write};
+use std::os::unix::io::{AsRawFd, RawFd};
+use tokio_io::{AsyncRead, AsyncWrite};
+
+use crate::AsyncPtyMaster;
+use AsAsyncPtyFd;
+
+pub fn split(master: AsyncPtyMaster) -> (AsyncPtyMasterReadHalf, AsyncPtyMasterWriteHalf) {
+    let (a, b) = BiLock::new(master);
+    (
+        AsyncPtyMasterReadHalf { handle: a },
+        AsyncPtyMasterWriteHalf { handle: b },
+    )
+}
+
+/// Read half of a AsyncPtyMaster, created with AsyncPtyMaster::split.
+pub struct AsyncPtyMasterReadHalf {
+    handle: BiLock<AsyncPtyMaster>,
+}
+
+/// Write half of a AsyncPtyMaster, created with AsyncPtyMaster::split.
+pub struct AsyncPtyMasterWriteHalf {
+    handle: BiLock<AsyncPtyMaster>,
+}
+
+impl AsAsyncPtyFd for AsyncPtyMasterReadHalf {
+    fn as_async_pty_fd(&self) -> Poll<RawFd, io::Error> {
+        let l = try_ready!(wrap_as_io(self.handle.poll_lock()));
+        Ok(Async::Ready(l.as_raw_fd()))
+    }
+}
+
+impl AsAsyncPtyFd for &AsyncPtyMasterReadHalf {
+    fn as_async_pty_fd(&self) -> Poll<RawFd, io::Error> {
+        let l = try_ready!(wrap_as_io(self.handle.poll_lock()));
+        Ok(Async::Ready(l.as_raw_fd()))
+    }
+}
+
+impl AsAsyncPtyFd for &mut AsyncPtyMasterReadHalf {
+    fn as_async_pty_fd(&self) -> Poll<RawFd, io::Error> {
+        let l = try_ready!(wrap_as_io(self.handle.poll_lock()));
+        Ok(Async::Ready(l.as_raw_fd()))
+    }
+}
+
+impl AsAsyncPtyFd for &AsyncPtyMasterWriteHalf {
+    fn as_async_pty_fd(&self) -> Poll<RawFd, io::Error> {
+        let l = try_ready!(wrap_as_io(self.handle.poll_lock()));
+        Ok(Async::Ready(l.as_raw_fd()))
+    }
+}
+
+impl AsAsyncPtyFd for &mut AsyncPtyMasterWriteHalf {
+    fn as_async_pty_fd(&self) -> Poll<RawFd, io::Error> {
+        let l = try_ready!(wrap_as_io(self.handle.poll_lock()));
+        Ok(Async::Ready(l.as_raw_fd()))
+    }
+}
+
+fn would_block() -> io::Error {
+    io::Error::new(io::ErrorKind::WouldBlock, "would block")
+}
+
+impl Read for AsyncPtyMasterReadHalf {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self.handle.poll_lock() {
+            Async::Ready(mut l) => l.read(buf),
+            Async::NotReady => Err(would_block()),
+        }
+    }
+}
+
+impl AsyncRead for AsyncPtyMasterReadHalf {
+    fn read_buf<B: BufMut>(&mut self, buf: &mut B) -> Poll<usize, io::Error> {
+        let mut l = try_ready!(wrap_as_io(self.handle.poll_lock()));
+        l.read_buf(buf)
+    }
+}
+
+impl Write for AsyncPtyMasterWriteHalf {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self.handle.poll_lock() {
+            Async::Ready(mut l) => l.write(buf),
+            Async::NotReady => Err(would_block()),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match self.handle.poll_lock() {
+            Async::Ready(mut l) => l.flush(),
+            Async::NotReady => Err(would_block()),
+        }
+    }
+}
+
+impl AsyncWrite for AsyncPtyMasterWriteHalf {
+    fn shutdown(&mut self) -> Poll<(), io::Error> {
+        let mut l = try_ready!(wrap_as_io(self.handle.poll_lock()));
+        l.shutdown()
+    }
+
+    fn write_buf<B: Buf>(&mut self, buf: &mut B) -> Poll<usize, io::Error>
+    where
+        Self: Sized,
+    {
+        let mut l = try_ready!(wrap_as_io(self.handle.poll_lock()));
+        l.write_buf(buf)
+    }
+}
+
+fn wrap_as_io<T>(t: Async<T>) -> Result<Async<T>, io::Error> {
+    Ok(t)
+}

--- a/tokio-pty-process/src/split.rs
+++ b/tokio-pty-process/src/split.rs
@@ -1,29 +1,12 @@
-// Copyright (c) 2019 Fabian Freyer
-// Copyright (c) 2018 Tokio Contributors
-//
-// Permission is hereby granted, free of charge, to any
-// person obtaining a copy of this software and associated
-// documentation files (the "Software"), to deal in the
-// Software without restriction, including without
-// limitation the rights to use, copy, modify, merge,
-// publish, distribute, sublicense, and/or sell copies of
-// the Software, and to permit persons to whom the Software
-// is furnished to do so, subject to the following
-// conditions:
-//
-// The above copyright notice and this permission notice
-// shall be included in all copies or substantial portions
-// of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-// ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-// SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-// IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-// DEALINGS IN THE SOFTWARE.
+// Copyright 2018 Peter Williams, Tokio Contributors
+// Copyright 2019 Fabian Freyer
+// Licensed under both the MIT License and the Apache-2.0 license.
+
+//! This module is a clone of
+//! <https://github.com/tokio-rs/tokio/blob/master/tokio-io/src/split.rs>
+//! (commit 1119d57), modified to refer to our AsyncPtyMaster types. We need
+//! to implement the splitting ourselves in order to be able to implement
+//! AsRawFd for the split types.
 
 use bytes::{Buf, BufMut};
 use futures::sync::BiLock;


### PR DESCRIPTION
Add an `AsyncPtyMaster::split()` method that allows splitting the `AsyncPtyMaster` into:
* an `AsyncPtyMasterReadHalf` implementing `Read` and `AsyncRead`, as well as
* an `AsyncPtyMasterWriteHalf` implementing `Write` and `AsyncWrite`.

This functionality mirrors [tokio_io::AsyncRead::split()], therefore the code is mostly taken from [tokio/tokio-io/src/split.rs].

The advantage of doing this over using tokio_io::AsyncRead::split() is that we can implement own traits over the halves.

Also add a `Trait AsAsyncPtyFd` that allows asynchronously getting the `RawFd` backing the PTY master. This is implemented for `AsyncPtyMaster`, as well as for the halves returned by `AsyncPtyMaster::split()`

[tokio/tokio-io/src/split.rs]: https://github.com/tokio-rs/tokio/blob/master/tokio-io/src/split.rs
[tokio_io::AsyncRead::split()]: https://docs.rs/tokio-io/0.1.10/tokio_io/trait.AsyncRead.html#method.split

This PR sets up for a future `Trait Pty` that implements functions such as resize etc.